### PR TITLE
Add markdown articles feature

### DIFF
--- a/app/articles/[slug].tsx
+++ b/app/articles/[slug].tsx
@@ -1,0 +1,35 @@
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { getArticleBySlug, markdownToHtml } from '../../lib/markdown';
+
+interface ArticleProps {
+  content: string;
+}
+
+export default function Article({ content }: ArticleProps) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: content }} />
+  );
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const article = getArticleBySlug(params?.slug as string);
+  const content = await markdownToHtml(article.content || '');
+
+  return {
+    props: {
+      content,
+    },
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const articles = getAllArticles();
+  const paths = articles.map((article) => ({
+    params: { slug: article.slug },
+  }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import Image from 'next/image'
 import { getGitHubStats, getTopRepositories, getLanguageStats, getLanguageColors } from "../lib/github"
+import Link from 'next/link'
 
 export const revalidate = 3600 // revalidate every hour
 
@@ -151,7 +152,22 @@ export default async function Home() {
           ))}
         </div>
       </section>
+
+      {/* Articles Section */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-bold mb-6 text-gray-100">Articles</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <Card className="bg-gray-900 border-gray-800 hover:border-gray-700 transition-colors">
+            <CardContent className="pt-6">
+              <h3 className="font-semibold text-gray-100 mb-2">Sample Article</h3>
+              <p className="text-gray-400 text-sm mb-4">This is a sample article rendered from markdown.</p>
+              <Link href="/articles/sample-article" className="text-blue-400 hover:text-blue-300 transition-colors">
+                Read more
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
     </main>
   )
 }
-

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { remark } from 'remark';
+import html from 'remark-html';
+
+const articlesDirectory = path.join(process.cwd(), 'articles');
+
+export async function markdownToHtml(markdown: string) {
+  const result = await remark().use(html).process(markdown);
+  return result.toString();
+}
+
+export function getArticleBySlug(slug: string) {
+  const fullPath = path.join(articlesDirectory, `${slug}.md`);
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
+
+  return {
+    slug,
+    content: fileContents,
+  };
+}

--- a/public/sample-article.md
+++ b/public/sample-article.md
@@ -1,0 +1,19 @@
+# Sample Article
+
+This is a sample markdown article.
+
+## Section 1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+## Section 2
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+## Section 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Conclusion
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
Fixes #2

Add feature to render markdown articles.

* Add `app/articles/[slug].tsx` to render markdown articles using `getStaticProps` and `getStaticPaths`.
* Add `lib/markdown.ts` to handle markdown to HTML conversion and fetching article content by slug.
* Modify `app/page.tsx` to include a section with links to markdown articles.
* Add `public/sample-article.md` as a sample markdown article.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/toufu-24/portfolio/pull/3?shareId=16cc3962-7d6c-4b79-b397-9dfbe6941da5).